### PR TITLE
fix: Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,15 @@ WORKDIR /build-stage
 COPY package*.json ./
 RUN npm ci
 COPY . ./
-RUN npm run prisma:generate && \
-    npm run build
+RUN npm run build
 
-FROM alpine:${ALPINE_VERSION}
+FROM node:18-alpine${ALPINE_VERSION}
 WORKDIR /usr/src/app
-RUN apk add --no-cache libstdc++ dumb-init \
-  && addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node \
-  && chown node:node ./
-COPY --from=builder /usr/local/bin/node /usr/local/bin/
 USER node
-COPY --from=builder /build-stage/node_modules ./node_modules
-COPY --from=builder /build-stage/dist ./dist
-COPY --from=builder /build-stage/package.json ./
+COPY --from=builder --chown=node:node /build-stage/node_modules ./node_modules
+COPY --from=builder --chown=node:node /build-stage/dist ./dist
+COPY --from=builder --chown=node:node /build-stage/package.json ./
+COPY --from=builder --chown=node:node /build-stage/prisma ./prisma
+COPY --from=builder --chown=node:node /build-stage/scripts/entrypoint.sh ./
 
-ENTRYPOINT ["dumb-init", "node", "--experimental-import-meta-resolve", "dist/index.js"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+npm run prisma:generate
+npm run prisma:push
+node --experimental-import-meta-resolve dist/index.js


### PR DESCRIPTION
# Reason for Change
Prisma commands (`generate` and `push`) modify/mutate its lib inside node_modules dir, which leads to non deterministic runs and fail db schema transactions on [internal bridge-indexer crons](https://github.com/availproject/bridge-ui-indexer/blob/4051273ff5fb994e07cd53904973ed07da925c67/src/index.ts#L105C5-L105C48).

Entrypoint script approach was adopted to allow prisma DB schema syncs.
Running the commands on container runtime allows image reusability among networks, w/o building images to each net.

## Tests
```js
╰─$ docker run -ti --rm availj/bridge-indexer:v0.1.1

> bridge-ui-indexer@1.0.0 prisma:generate
> prisma generate

Prisma schema loaded from prisma/schema.prisma

✔ Generated Prisma Client (v5.13.0) to ./node_modules/@prisma/client in 222ms
```