### PR TITLE
feat: Updates mainnet bridge address and startBlock

### DIFF
--- a/subgraph/config/mainnet.json
+++ b/subgraph/config/mainnet.json
@@ -2,8 +2,8 @@
   "network": "mainnet",
   "contracts": {
     "AvailBridge": {
-      "address": "0x75545225c83b985f3a517bf61f316266057bb13b",
-      "startBlock": 5200000
+      "address": "0x272292eC4d451bf13316c4bD797B55A496aF5F82",
+      "startBlock": 19819800
     }
   }
 }


### PR DESCRIPTION
## Changes
- [x] Updates mainnet bridge address and startBlock

## Reason for Change
Allows Bridge Indexer deployment on mainnet network

Subgraph deployed on Alchemy under v0.1.0 release.

```elixir
graph deploy avail-bridge-mainnet \
  --version-label v0.1.0 \
  --node https://subgraphs.alchemy.com/api/subgraphs/deploy \
  --deploy-key <REDACTED> \
  --ipfs https://ipfs.satsuma.xyz
```