### PR TITLE
fix: cron operation haulting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,27 +112,27 @@ async function startCron() {
 
     startFunction(
       transactionCron.updateEthereumSend.bind(transactionCron),
-      Number(process.env.ETHEREUM_SEND_CRON_INTERVAL) || 120
+      Number(process.env.ETHEREUM_SEND_CRON_INTERVAL) || 120000
     );
     startFunction(
       transactionCron.updateEthereumReceive.bind(transactionCron),
-      Number(process.env.ETHEREUM_RECEIVE_CRON_INTERVAL) || 120
+      Number(process.env.ETHEREUM_RECEIVE_CRON_INTERVAL) || 120000
     );
     startFunction(
       transactionCron.updateSendOnAvail.bind(transactionCron),
-      Number(process.env.SEND_ON_AVAIL_CRON_INTERVAL) || 120
+      Number(process.env.SEND_ON_AVAIL_CRON_INTERVAL) || 120000
     );
     startFunction(
       transactionCron.updateReceiveOnAvail.bind(transactionCron),
-      Number(process.env.RECEIVE_ON_AVAIL_CRON_INTERVAL) || 120
+      Number(process.env.RECEIVE_ON_AVAIL_CRON_INTERVAL) || 120000
     );
     startFunction(
       transactionCron.updateAvlToEthToReadyToClaim.bind(transactionCron),
-      Number(process.env.AVL_TO_ETH_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120
+      Number(process.env.AVL_TO_ETH_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120000
     );
     startFunction(
       transactionCron.updateEthToAvlToReadyToClaim.bind(transactionCron),
-      Number(process.env.ETH_TO_AVL_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120
+      Number(process.env.ETH_TO_AVL_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120000
     );
   } catch (error) {
     logger.error("error in syncing All transactions: ", error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,27 +112,27 @@ async function startCron() {
 
     startFunction(
       transactionCron.updateEthereumSend.bind(transactionCron),
-      Number(process.env.ETHEREUM_SEND_CRON_INTERVAL) || 120000
+      Number(process.env.ETHEREUM_SEND_CRON_INTERVAL) || 120
     );
     startFunction(
       transactionCron.updateEthereumReceive.bind(transactionCron),
-      Number(process.env.ETHEREUM_RECEIVE_CRON_INTERVAL) || 120000
+      Number(process.env.ETHEREUM_RECEIVE_CRON_INTERVAL) || 120
     );
     startFunction(
       transactionCron.updateSendOnAvail.bind(transactionCron),
-      Number(process.env.SEND_ON_AVAIL_CRON_INTERVAL) || 120000
+      Number(process.env.SEND_ON_AVAIL_CRON_INTERVAL) || 120
     );
     startFunction(
       transactionCron.updateReceiveOnAvail.bind(transactionCron),
-      Number(process.env.RECEIVE_ON_AVAIL_CRON_INTERVAL) || 120000
+      Number(process.env.RECEIVE_ON_AVAIL_CRON_INTERVAL) || 120
     );
     startFunction(
       transactionCron.updateAvlToEthToReadyToClaim.bind(transactionCron),
-      Number(process.env.AVL_TO_ETH_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120000
+      Number(process.env.AVL_TO_ETH_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120
     );
     startFunction(
       transactionCron.updateEthToAvlToReadyToClaim.bind(transactionCron),
-      Number(process.env.ETH_TO_AVL_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120000
+      Number(process.env.ETH_TO_AVL_TO_READY_TO_CLAIM_CRON_INTERVAL) || 120
     );
   } catch (error) {
     logger.error("error in syncing All transactions: ", error);

--- a/src/services/eth-indexer.ts
+++ b/src/services/eth-indexer.ts
@@ -2,7 +2,7 @@ import { request, gql } from "graphql-request";
 import { IEthSendMessage, IEthReceiveMessage } from "../types/index.js";
 import logger from "../helpers/logger.js";
 export default class EthIndexer {
-  constructor(private subgraphUrl: string) { }
+  constructor(private subgraphUrl: string) {}
 
   async getSendMessageTx(
     startBlockNumber: number,


### PR DESCRIPTION
Note: Now the process never exists but the log ""error in syncing All transactions:" will also as a result never get triggered. Is this what we want?
Was thinking alternatively i can always restart it in a loop, but i feel like that can leave existing non errored cron jobs running in the background. This seems like a safer design specially considering limited time