### PR TITLE
fix: Start execution flow logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,11 +142,11 @@ async function startCron() {
 async function start() {
   bridgeApi = new BridgeApi(process.env.BRIDGE_API as string);
 
-  if (process.env.START_CRON) {
+  if (process.env.START_CRON == 'true') {
     await startCron();
   }
 
-  if (process.env.START_API) {
+  if (process.env.START_API == 'true') {
     await startApi();
   }
 }


### PR DESCRIPTION
# Reason for Change
- Execution of Cron services kept running even on START_CRON=false.
Reason is that all envs are loaded as strings on runtime and marvelous Javascript returns the following:

**Debug value:**
<img src="https://github.com/user-attachments/assets/1cb5f168-a6f8-43b8-a570-cebafcbea79f" width=50%>

**node REPL:**
```rust
> ('false') ? "TRUE" : "FALSE"
'TRUE'
``` 

Adding obvious string comparison fix the execution flow for both cron and rest services.

```rust
> ('false' == 'false') ? "TRUE" : "FALSE"
'TRUE'
> ('false' == 'true') ? "TRUE" : "FALSE"
'FALSE'
``` 