### PR TITLE
feat: Adds Tests + Decouples parseAmount fn + fix BigNumber inital parse

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+on:
+  push:
+    branches-ignore:
+      - main
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    container: node:20.15-alpine
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install
+        run: npm install
+      - name: Run tests
+        id: run_node_tests
+        run: |
+            npm run test --verbose

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --loader ts-node/esm src/tests/*.ts",
     "build": "tsup",
     "start": "node --experimental-import-meta-resolve dist/index.js",
     "lint": "eslint src/**/*.ts",

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -1,0 +1,10 @@
+import { ethers } from "ethers";
+
+export default function parseAmount(numberString: string): string {
+  try {
+    const number = BigInt(numberString);
+    return ethers.formatEther(number).toString();
+  } catch (e) {
+    return "";
+  }
+}

--- a/src/services/transaction-cron.ts
+++ b/src/services/transaction-cron.ts
@@ -644,7 +644,7 @@ export default class TransactionCron {
           amount: new BigNumber(
             value.message.fungibleToken.amount,
             16
-          ).toString(),
+          ).toFixed(),
           dataType: "ERC20",
           status: "CLAIMED",
           destinationBlockHash: data.block.hash,
@@ -655,7 +655,7 @@ export default class TransactionCron {
         {
           ...sourceObj(),
           amountPrettified: parseAmount(
-            new BigNumber(value.message.fungibleToken.amount, 16).toFixed(0)
+            new BigNumber(value.message.fungibleToken.amount, 16).toFixed()
           ),
         },
         "MessageExecuted"

--- a/src/services/transaction-cron.ts
+++ b/src/services/transaction-cron.ts
@@ -10,6 +10,7 @@ import { decodeParameter, decodeParameters } from "web3-eth-abi";
 import {ethers} from "ethers";
 
 import logger from "../helpers/logger.js";
+import parseAmount from "../helpers/parser.js";
 import {
   IAvailEvent,
   IAvailExtrinsic,
@@ -654,7 +655,7 @@ export default class TransactionCron {
         {
           ...sourceObj(),
           amountPrettified: parseAmount(
-            new BigNumber(value.message.fungibleToken.amount, 16).toString()
+            new BigNumber(value.message.fungibleToken.amount, 16).toFixed(0)
           ),
         },
         "MessageExecuted"
@@ -679,14 +680,5 @@ export default class TransactionCron {
     } catch (error) {
       logger.error("An error occurred during the transaction:", error);
     }
-  }
-}
-
-function parseAmount(numberString: string): string {
-  try {
-    const number = BigInt(numberString);
-    return ethers.formatEther(number).toString();
-  } catch (e) {
-    return "";
   }
 }

--- a/src/services/transaction-cron.ts
+++ b/src/services/transaction-cron.ts
@@ -644,7 +644,7 @@ export default class TransactionCron {
           amount: new BigNumber(
             value.message.fungibleToken.amount,
             16
-          ).toFixed(),
+          ).toString(),
           dataType: "ERC20",
           status: "CLAIMED",
           destinationBlockHash: data.block.hash,

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -1,0 +1,22 @@
+import assert from "assert/strict"
+import { BigNumber } from "bignumber.js";
+import parseAmount from "../helpers/parser.js";
+
+function testNormalBigAmount(){
+    const rawFungibleTokenAmount = "0x00000000000000000de0b6b3a7640000";
+    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+    const amountPrettified = parseAmount(bigNumberString)
+    const expectedParsedAmount = "1.0"
+    assert.deepStrictEqual(amountPrettified,expectedParsedAmount)
+}
+
+function testScientificBigAmount() {
+    const rawFungibleTokenAmount = "0x000000000000182a697403a1b0cf0ad2";
+    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+    const amountPrettified = parseAmount(bigNumberString)
+    const expectedParsedAmount = "114119.157542431558142674"
+    assert.deepStrictEqual(amountPrettified,expectedParsedAmount)
+}
+
+testNormalBigAmount()
+testScientificBigAmount()

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -1,22 +1,22 @@
-import assert from "assert/strict"
+import assert from "assert/strict";
 import { BigNumber } from "bignumber.js";
 import parseAmount from "../helpers/parser.js";
 
-function testNormalBigAmount(){
-    const rawFungibleTokenAmount = "0x00000000000000000de0b6b3a7640000";
-    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
-    const amountPrettified = parseAmount(bigNumberString)
-    const expectedParsedAmount = "1.0"
-    assert.deepStrictEqual(amountPrettified,expectedParsedAmount)
+function testNormalBigAmount() {
+  const rawFungibleTokenAmount = "0x00000000000000000de0b6b3a7640000";
+  const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+  const amountPrettified = parseAmount(bigNumberString);
+  const expectedParsedAmount = "1.0";
+  assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
 }
 
 function testScientificBigAmount() {
-    const rawFungibleTokenAmount = "0x000000000000182a697403a1b0cf0ad2";
-    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
-    const amountPrettified = parseAmount(bigNumberString)
-    const expectedParsedAmount = "114119.157542431558142674"
-    assert.deepStrictEqual(amountPrettified,expectedParsedAmount)
+  const rawFungibleTokenAmount = "0x000000000000182a697403a1b0cf0ad2";
+  const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+  const amountPrettified = parseAmount(bigNumberString);
+  const expectedParsedAmount = "114119.157542431558142674";
+  assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
 }
 
-testNormalBigAmount()
-testScientificBigAmount()
+testNormalBigAmount();
+testScientificBigAmount();

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -1,22 +1,22 @@
 import assert from "assert/strict";
+import { describe, it } from "node:test";
 import { BigNumber } from "bignumber.js";
 import parseAmount from "../helpers/parser.js";
 
-function testNormalBigAmount() {
-  const rawFungibleTokenAmount = "0x00000000000000000de0b6b3a7640000";
-  const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
-  const amountPrettified = parseAmount(bigNumberString);
-  const expectedParsedAmount = "1.0";
-  assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
-}
+describe("Test tx amount parse", () => {
+  it("Should parse rawFungibleTokenAmount on 18 digit BigNumber value", () => {
+    const rawFungibleTokenAmount = "0x00000000000000000de0b6b3a7640000";
+    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+    const amountPrettified = parseAmount(bigNumberString);
+    const expectedParsedAmount = "1.0";
+    assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
+  });
 
-function testScientificBigAmount() {
-  const rawFungibleTokenAmount = "0x000000000000182a697403a1b0cf0ad2";
-  const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
-  const amountPrettified = parseAmount(bigNumberString);
-  const expectedParsedAmount = "114119.157542431558142674";
-  assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
-}
-
-testNormalBigAmount();
-testScientificBigAmount();
+  it("Should parse rawFungibleTokenAmount on 24 digit scientific BigNumber value", () => {
+    const rawFungibleTokenAmount = "0x000000000000182a697403a1b0cf0ad2";
+    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+    const amountPrettified = parseAmount(bigNumberString);
+    const expectedParsedAmount = "114119.157542431558142674";
+    assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
+  });
+});

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -6,7 +6,7 @@ import parseAmount from "../helpers/parser.js";
 describe("Test tx amount parse", () => {
   it("Should parse rawFungibleTokenAmount on 18 digit BigNumber value", () => {
     const rawFungibleTokenAmount = "0x00000000000000000de0b6b3a7640000";
-    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed();
     const amountPrettified = parseAmount(bigNumberString);
     const expectedParsedAmount = "1.0";
     assert.deepStrictEqual(amountPrettified, expectedParsedAmount);
@@ -14,7 +14,7 @@ describe("Test tx amount parse", () => {
 
   it("Should parse rawFungibleTokenAmount on 24 digit scientific BigNumber value", () => {
     const rawFungibleTokenAmount = "0x000000000000182a697403a1b0cf0ad2";
-    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed(0);
+    const bigNumberString = BigNumber(rawFungibleTokenAmount, 16).toFixed();
     const amountPrettified = parseAmount(bigNumberString);
     const expectedParsedAmount = "114119.157542431558142674";
     assert.deepStrictEqual(amountPrettified, expectedParsedAmount);


### PR DESCRIPTION
## Description
- [x] Decouples parseAmount fn 
- [x] Fix BigNumber inital parse (toFixed instead of toString)
- [x] Add test cases using node.js assert and test suite API (AAA pattern).

## Related Issue
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/availproject/helm-values/issues

## Motivation and Context
`parseAmount fn` can't handle scientific notated numbers, therefore it throws an error and returns an empty string.
Must guarantee that all BigNumbers previously parsed will be strings not on scientific notation.
As per [BigNumber.js docs](https://github.com/MikeMcl/bignumber.js?tab=readme-ov-file#use) it's recommended `toFixed` instead of `toString` to avoid scientific notation.

## How Has This Been Tested?
Github Actions Run [#Test 2](https://github.com/availproject/bridge-ui-indexer/actions/runs/10277705543/job/28440151039)

## Screenshots (if appropriate)
