### PR TITLE
fix: Rollback default export declaration

### DIFF
--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import {BigNumber} from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 
 export default function parseAmount(numberString: string): string {
   try {

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import {BigNumber} from "bignumber.js";
 
-export function parseAmount(numberString: string): string {
+export default function parseAmount(numberString: string): string {
   try {
     const number = BigNumber(numberString).toFixed();
     return ethers.formatEther(number).toString();

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert/strict";
 import { describe, it } from "node:test";
 import { BigNumber } from "bignumber.js";
-import {parseAmount} from "../helpers/parser.js";
+import parseAmount from "../helpers/parser.js";
 
 describe("Test tx amount parse", () => {
   it("Should parse rawFungibleTokenAmount on 18 digit BigNumber value", () => {


### PR DESCRIPTION
## Description
- [x] Rollback default export declaration on parseAmount fn 
- [x] Lint Parser
## Related Issue
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
[Build broke](https://github.com/availproject/bridge-ui-indexer/actions/runs/10311778179/job/28545934568) after removing default export. Rollback it so both tests and build can pass.

## How Has This Been Tested?
Locally:
```rust
╰─$ npm run test

> bridge-ui-indexer@1.0.0 test
> node --loader ts-node/esm src/tests/*.ts

(Use `node --trace-warnings ...` to show where the warning was created)
▶ Test tx amount parse
  ✔ Should parse rawFungibleTokenAmount on 18 digit BigNumber value (5.033581ms)
  ✔ Should parse rawFungibleTokenAmount on 24 digit scientific BigNumber value (1.136583ms)
  ✔ Should parse scientific notation (0.545487ms)
  ✔ Should parse regular number (0.457684ms)
▶ Test tx amount parse (9.530578ms)
ℹ tests 4
ℹ suites 1
ℹ pass 4
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 24.997713
```

```rust
╰─$ docker build --no-cache --platform=linux/amd64 -t availj/bridge-indexer:v1.1.3-rc1 -f Dockerfile .
[+] Building 69.7s (17/17) FINISHED                                                                                                                       docker:default
 => [internal] load .dockerignore                                                                                                                                   0.0s
 => => transferring context: 92B                                                                                                                                    0.0s
 => [internal] load build definition from Dockerfile                                                                                                                0.0s
 => => transferring dockerfile: 647B                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/node:18-alpine3.19                                                                                               1.3s
 => [internal] load build context                                                                                                                                   1.2s
 => => transferring context: 1.83MB                                                                                                                                 1.1s
 => [builder 1/6] FROM docker.io/library/node:18-alpine3.19@sha256:dfc737c864950bb3a56546b99ba2d2479d693d6563460a379fb56fe7ccfe6967                                 0.0s
 => => resolve docker.io/library/node:18-alpine3.19@sha256:dfc737c864950bb3a56546b99ba2d2479d693d6563460a379fb56fe7ccfe6967                                         0.0s
 => CACHED [stage-1 2/7] WORKDIR /usr/src/app                                                                                                                       0.0s
 => CACHED [builder 2/6] WORKDIR /build-stage                                                                                                                       0.0s
 => [builder 3/6] COPY package*.json ./                                                                                                                             0.3s
 => [builder 4/6] RUN npm ci                                                                                                                                       24.4s
 => [builder 5/6] COPY . ./                                                                                                                                         5.5s
 => [builder 6/6] RUN npm run build                                                                                                                                20.6s 
 => [stage-1 3/7] COPY --from=builder --chown=node:node /build-stage/node_modules ./node_modules                                                                    3.9s 
 => [stage-1 4/7] COPY --from=builder --chown=node:node /build-stage/dist ./dist                                                                                    0.1s 
 => [stage-1 5/7] COPY --from=builder --chown=node:node /build-stage/package.json ./                                                                                0.1s 
 => [stage-1 6/7] COPY --from=builder --chown=node:node /build-stage/prisma ./prisma                                                                                0.0s 
 => [stage-1 7/7] COPY --from=builder --chown=node:node /build-stage/scripts/entrypoint.sh ./                                                                       0.1s 
 => exporting to image                                                                                                                                              5.1s 
 => => exporting layers                                                                                                                                             5.1s
 => => writing image sha256:301068231c412a5fe1d2d71c14dcfe80f952a8b062779cafeaf81b703d3f344c                                                                        0.0s
 => => naming to docker.io/availj/bridge-indexer:v1.1.3-rc1
```
## Screenshots (if appropriate)
