### PR TITLE
fix: Amount column format on ethereumsends table

### DIFF
--- a/src/services/transaction-cron.ts
+++ b/src/services/transaction-cron.ts
@@ -644,7 +644,7 @@ export default class TransactionCron {
           amount: new BigNumber(
             value.message.fungibleToken.amount,
             16
-          ).toString(),
+          ).toFixed(),
           dataType: "ERC20",
           status: "CLAIMED",
           destinationBlockHash: data.block.hash,


### PR DESCRIPTION
# Problem Statement
Amount column on `ethereumsends` table has no standard format.

# How was it tested?
Tested on hex:
- [x] Deploy new DB Cluster
- [x] Deploy new indexer on hex and use new DB cluster
- [x] Check `amount` field.

Amount field was correctly parsed on hex