### PR TITLE
Remove beacon API call, superceeded by head call. Use proper version enpoints of BridgeAPI.

### DIFF
--- a/src/services/bridge-api.ts
+++ b/src/services/bridge-api.ts
@@ -7,35 +7,28 @@ export default class BridgeApi {
     async getAvailLatestHeadOnEthereum(): Promise<AxiosResponse<any>> {
         return await axios({
             method: "get",
-            url: `${this.url}/avl/head`,
+            url: `${this.url}/v1/avl/head`,
         });
     }
 
     async getEthLatestHeadOnAvail(): Promise<AxiosResponse<any>> {
         return await axios({
             method: "get",
-            url: `${this.url}/eth/head`,
-        });
-    }
-
-    async getBlockNumberBySlot(slot: number): Promise<AxiosResponse<any>> {
-        return await axios({
-            method: "get",
-            url: `${this.url}/beacon/slot/${slot}`,
+            url: `${this.url}/v1/eth/head`,
         });
     }
 
     async getProofToSubmitOnEthereum(blockHash: string, transactionIndex: string): Promise<AxiosResponse<any>> {
         return await axios({
             method: "get",
-            url: `${this.url}/eth/proof/${blockHash}?index=${transactionIndex}`,
+            url: `${this.url}/v1/eth/proof/${blockHash}?index=${transactionIndex}`,
         });
     }
 
     async getProofToSubmitOnAvail(blockHash: string, messageId: string): Promise<AxiosResponse<any>> {
         return await axios({
             method: "get",
-            url: `${this.url}/avl/proof/${blockHash}/${messageId}`,
+            url: `${this.url}/v1/avl/proof/${blockHash}/${messageId}`,
         });
     }
 

--- a/src/services/transaction-cron.ts
+++ b/src/services/transaction-cron.ts
@@ -266,21 +266,17 @@ export default class TransactionCron {
     try {
       let response = await this.bridgeApi.getEthLatestHeadOnAvail();
 
-      if (response && response.data && response.data.slot) {
-        let block = await this.bridgeApi.getBlockNumberBySlot(
-          response.data.slot
-        );
-        if (block && block.data && block.data.blockNumber) {
+      if (response && response.data && response.data.blockNumber) {
+        let blockNumber = response.data.blockNumber
           await prisma.ethereumsends.updateMany({
             where: {
               status: "BRIDGED",
-              sourceBlockNumber: { lte: block.data.blockNumber },
+              sourceBlockNumber: { lte: blockNumber },
             },
             data: {
               status: "READY_TO_CLAIM",
             },
           });
-        }
       }
     } catch (error) {
       logger.error(


### PR DESCRIPTION
This is dependent on https://github.com/availproject/bridge-api/pull/27

The BridgeApi PR eliminates the beacon endpoint and instead introduces the necessary info into eth/head API. This PR introduces that into indexer.